### PR TITLE
feat: add eco malus

### DIFF
--- a/vuejs_app/src/classes/City.ts
+++ b/vuejs_app/src/classes/City.ts
@@ -94,7 +94,7 @@ export class City {
 
     updateCash() {
         setInterval(() => {
-            this.cashQuantity += this.gainPerSec;
+            this.cashQuantity += this.gainPerSec * (this.ecoPourcentage / 100);
           }, 1000);
     }
 


### PR DESCRIPTION
Refs: MGWT-108

L'argent par secondes est modifié selon l"écologie. 10 par sec avec 100% d'éco donne 10;  10 par sec avec 50% d'éco donne 5; etc...